### PR TITLE
Fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/NVIDIA/terraform-provider-mcahr/security/code-scanning/2](https://github.com/NVIDIA/terraform-provider-mcahr/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, while `contents: write` may be required for specific actions like signing commits or interacting with pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions. In this case, adding it at the root level is appropriate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
