### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build releases
         run: make release
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.MCAHR_BUILD_AWS_KEY }}
           aws-secret-access-key: ${{ secrets.MCAHR_BUILD_AWS_SEC }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `aws-actions/configure-aws-credentials` | [`v1`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1) | [`v5`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5) | [Release](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5) | main.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
